### PR TITLE
feat: optimize build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,6 @@
 !yarn.lock
 !src
 !bin
+!tsconfig.json
+!tsconfig.app.json
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: docker-config
-        uses: renovatebot/internal-tools@v0
-        with:
-          command: docker-config
-
       - name: Docker registry login
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -18,11 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: docker-config
-        uses: renovatebot/internal-tools@v0
-        with:
-          command: docker-config
-
       - name: Docker registry login
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,10 @@ RUN yarn install --link-duplicates
 COPY tsconfig.json .
 COPY tsconfig.app.json .
 COPY src src
-RUN yarn build
+
+RUN set -ex; \
+  yarn build; \
+  chmod +x dist/*.js;
 
 ARG RENOVATE_VERSION
 RUN yarn add renovate@${RENOVATE_VERSION} --link-duplicates
@@ -42,8 +45,6 @@ RUN yarn install --link-duplicates --production
 # check is re2 is usable
 RUN node -e "new require('re2')('.*').exec('test')"
 
-RUN set -ex; \
-  chmod +x dist/*.js;
 
 # TODO: enable
 #COPY src src

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ COPY --from=tsbuild /usr/src/app/node_modules node_modules
 
 # exec helper
 COPY bin/ /usr/local/bin/
-RUN ln -sf /usr/src/app/dist/index.js /usr/local/bin/renovate;
+RUN ln -sf /usr/src/app/dist/renovate.js /usr/local/bin/renovate;
 RUN ln -sf /usr/src/app/dist/config-validator.js /usr/local/bin/renovate-config-validator;
 CMD ["renovate"]
 

--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@ $ docker run --rm -it -v $PWD/config.js:/usr/src/app/config.js -v /tmp:/tmp -v /
 $ export RENOVATE_TOKEN=xxxxxxx
 $ docker run --rm -it -e RENOVATE_TOKEN -v /tmp:/tmp -v /var/run/docker.sock:/var/run/docker.sock renovate/renovate:slim renovate-tests/gomod1
 ```
+
+#### config-validator
+```sh
+$ docker run --rm -it -v $PWD/config.js:/usr/src/app/config.js -e LOG_LEVEL=debug renovate/renovate:slim renovate-config-validator
+```

--- a/builder.json
+++ b/builder.json
@@ -1,5 +1,5 @@
 {
   "image": "renovate",
-  "startVersion": "20.0.0",
+  "startVersion": "21.0.0",
   "cache": "docker-build-cache"
 }

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
   "license": "AGPL-3.0",
   "private": true,
   "scripts": {
-    "build": "ncc build src/index.js"
+    "build": "tsc -p tsconfig.app.json"
   },
   "dependencies": {
-    "renovate": "21.29.3"
+    "renovate": "21.29.3",
+    "source-map-support": "0.5.19",
+    "tslib": "2.0.0"
   },
   "devDependencies": {
-    "@zeit/ncc": "0.22.3"
+    "@types/bunyan": "1.8.6",
+    "typescript": "3.9.6"
   }
 }

--- a/src/config-validator.ts
+++ b/src/config-validator.ts
@@ -1,3 +1,9 @@
 #!/usr/bin/env node
 import 'source-map-support/register'
+import { logger } from 'renovate/dist/logger';
+
+if (process.argv[1] !== '/usr/local/bin/renovate-config-validator') {
+  logger.warn("Deprecated! Please use global 'renovate-config-validator' command.");
+}
+
 import 'renovate/dist/config-validator';

--- a/src/config-validator.ts
+++ b/src/config-validator.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import 'source-map-support/register'
+import 'renovate/dist/config-validator';

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,0 @@
-import 'renovate/dist/renovate.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-import 'source-map-support/register'
-import 'renovate/dist/renovate';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import 'source-map-support/register'
+import 'renovate/dist/renovate';

--- a/src/renovate.ts
+++ b/src/renovate.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import {logger} from 'renovate/dist/logger';
+logger.warn('Deprecated! Please use global \'renovate\' command.')
+
+import 'renovate/dist/renovate';

--- a/src/renovate.ts
+++ b/src/renovate.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
-import {logger} from 'renovate/dist/logger';
-logger.warn('Deprecated! Please use global \'renovate\' command.')
+import 'source-map-support/register';
+import { logger } from 'renovate/dist/logger';
+
+if (process.argv[1] !== '/usr/local/bin/renovate') {
+  logger.warn("Deprecated! Please use global 'renovate' command.");
+}
 
 import 'renovate/dist/renovate';

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "files": ["src/index.ts", "src/config-validator.ts", "src/renovate.ts"]
+  "files": ["src/renovate.ts", "src/config-validator.ts"]
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "files": ["src/index.ts", "src/config-validator.ts", "src/renovate.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "./dist",
+    "target": "es2018",
+    "module": "commonjs",
+    "sourceMap": true,
+    "lib": ["es2018"],
+    "types": [],
+  },
+  "exclude": [
+    "node_modules",
+    "./.cache",
+    "./dist",
+    "./bin",
+    "**/__mocks__/*",
+    "bin",
+    "coverage",
+    "tmp"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es2018",
     "module": "commonjs",
     "sourceMap": true,
+    "importHelpers": true,
     "lib": ["es2018"],
     "types": [],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,6 +38,13 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@types/bunyan@1.8.6":
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.6.tgz#6527641cca30bedec5feb9ab527b7803b8000582"
+  integrity sha512-YiozPOOsS6bIuz31ilYqR5SlLif4TBWsousN2aCWLi5233nZSX19tFbcQUPdR7xJ8ypPyxkCGNxg0CIV5n9qxQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -59,11 +66,6 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
-
-"@zeit/ncc@0.22.3":
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.22.3.tgz#fca6b86b4454ce7a7e1e7e755165ec06457f16cd"
-  integrity sha512-jnCLpLXWuw/PAiJiVbLjA8WBC0IJQbFeUwF4I9M+23MvIxTxk5pD4Q8byQBSPmHQjz5aBoA7AKAElQxMpjrCLQ==
 
 abbrev@1:
   version "1.1.1"
@@ -238,6 +240,11 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+buffer-from@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
 buffer@4.9.2:
   version "4.9.2"
@@ -2240,7 +2247,15 @@ slugify@1.4.4:
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.4.tgz#2f032ffa52b1e1ca2a27737c1ce47baae3d0883a"
   integrity sha512-N2+9NJ8JzfRMh6PQLrBeDEnVDQZSytE/W4BTC4fNNPmO90Uu58uNwSlIJSs+lmPgWsaAF79WLhVPe5tuy7spjw==
 
-source-map@^0.6.1:
+source-map-support@0.5.19:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -2485,6 +2500,11 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
+tslib@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
+  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -2520,6 +2540,11 @@ typed-rest-client@^1.7.3:
     qs "^6.9.1"
     tunnel "0.0.6"
     underscore "1.8.3"
+
+typescript@3.9.6:
+  version "3.9.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
+  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
* use typescript to validate
* add config-validator as `renovate-config-validator`
* warn if old `node /usr/src/app/dist/renovate.js` command is used

closes: #31