### PR TITLE
feat: limit max versions to build

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -1,5 +1,6 @@
 {
   "image": "renovate",
   "startVersion": "23.0.0",
-  "cache": "docker-build-cache"
+  "cache": "docker-build-cache",
+  "maxVersions": 10
 }


### PR DESCRIPTION
on last failed cron run we rebuild 166 versions. With this change we only rebuild latest 10 versions

closes #20 