### PR TITLE
docs: fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For the `latest` image see [here](https://github.com/renovatebot/docker-renovate
 
 ## Usage
 
-See [docs](https://github.com/renovatebot/renovate/blob/master/docs/development/self-hosting.md#self-hosting-renovate) for additional information to self-hosting renovate with docker.
+See [docs](https://github.com/renovatebot/renovate/blob/master/docs/usage/self-hosting.md#self-hosting-renovate) for additional information to self-hosting renovate with docker.
 
 
 See [Gitlab docs](./docs/gitlab.md) for some gitlab configuration samples.


### PR DESCRIPTION
Fixes link to Renovate self-hosting documentation.