### PR TITLE
docs(bitbucket): Update docker image version

### DIFF
--- a/docs/bitbucket.md
+++ b/docs/bitbucket.md
@@ -4,7 +4,7 @@ These are configuration examples for running a self-hosted Renovate on bitbucket
 
 ### bitbucket-pipelines.yml
 ```yml
-image: renovate/renovate:23.96.2-slim
+image: renovate/renovate:24.9.8-slim
 
 definitions:
   caches:


### PR DESCRIPTION
# Summary
Brings docker tag up to date with more recent version.

# Context/Rationale
We were having trouble with the algorithm that calcualtes PR hourly limit. After this upgrade, it was resolved.

Motivating issue (that I haven't written up): I note that this page includes a renovate.json that should upgrade the image automatically. However, at least with our configuration, this wasn't occurring. Perhaps the many other PRs that came immediately after onboarding are creating a bottleneck.