### PR TITLE
docs: update gitlab runner volumes re: certs

### DIFF
--- a/docs/gitlab.md
+++ b/docs/gitlab.md
@@ -39,7 +39,7 @@ Renovate will map `baseDir` to the docker side container running tools like `pyt
     disable_entrypoint_overwrite = false
     oom_kill_disable = false
     disable_cache = false
-    volumes = ["/cache", "/tmp:/tmp:rw", "/var/run/docker.sock:/var/run/docker.sock"]
+    volumes = ["/certs/client", "/cache", "/tmp:/tmp:rw", "/var/run/docker.sock:/var/run/docker.sock"]
     shm_size = 0
   [runners.cache]
     [runners.cache.s3]


### PR DESCRIPTION
Per:
https://gitlab.com/renovate-bot/renovate-runner/-/issues/20#note_534718858

It is necessary to map in the "/certs/client" volume or the Gitlab
renovate runner using `dind` will complain with errors like:

`unable to resolve docker endpoint: open /certs/client/ca.pem: no such
file or directory\n`

Signed-off-by: Matt Critchlow <mcritchlow@ucsd.edu>