### PR TITLE
fix: explicitly set github actions permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: '0 1 * * *'
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
After my commit to `renovatebot/internal-tools` to sign images by default[^1], builds have started failing[^2]. I think this is due to a lack of permissions for `GITHUB_TOKEN`. These permissions are listed in the starter workflow template[^3]. I'm not 100% sure what permissions `internal-tools` needs, but this seems like a good baseline, and any permissions not listed are set to `none`[^4]

> When the `permissions` key is used, all unspecified permissions are set to no access, with the exception of the `metadata` scope, which always gets read access.

[^1]: https://github.com/renovatebot/internal-tools/pull/261
[^2]: https://github.com/renovatebot/docker-renovate/runs/4679585005?check_suite_focus=true
[^3]: https://github.com/actions/starter-workflows/blob/f9d17c0062bdfb3d9b4294609989fb01dca2f357/ci/docker-publish.yml#L29-L34
[^4]: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token