### PR TITLE
Upgrade docker-dind image

### DIFF
--- a/docs/gitlab.md
+++ b/docs/gitlab.md
@@ -129,7 +129,7 @@ variables:
   LOG_LEVEL: debug
 
 services:
-  - docker:19.03-dind
+  - docker:20.10.14-dind-rootless
 
 before_script:
   # Prepare renovate directory


### PR DESCRIPTION
Upgrade doc with an up to date version of docker-dind and with rootless which is safer