### PR TITLE
chore: use valid SPDX license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "renovate-docker",
   "version": "0.0.0-PLACEHOLDER",
   "repository": "https://github.com/renovatebot/docker-renovate.git",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "author": "Rhys Arkins <rhys@arkins.net>",
   "contributors": [
     "Michael Kriese <michael.kriese@visualon.de>"


### PR DESCRIPTION
## Changes:

- Update to use a valid SPDX license identifier, as the old one is deprecated [^SPDX-License-List]

## Context:

This one was found by @viceice in:

- https://github.com/renovatebot/renovate/issues/17464

[^SPDX-License-List]: https://spdx.org/licenses/