### PR TITLE
fix: Revert "fix: explicit install npm"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,6 @@ RUN prepare-tool all
 RUN install-tool node v18.15.0
 
 # renovate: datasource=npm versioning=npm
-RUN install-tool npm 9.6.1
-
-# renovate: datasource=npm versioning=npm
 RUN install-tool yarn 1.22.19
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
Reverts renovatebot/docker-renovate#1147

we don't need it, it's only needed on full image at build time 