### PR TITLE
chore: no longer update v35 branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,11 @@
   "baseBranches": ["$default", "/^v\\d+$/"],
   "packageRules": [
     {
+      "description": "No longer updates these branches",
+      "matchBaseBranches": ["v35"],
+      "enabled": false
+    },
+    {
       "matchPackageNames": ["renovate"],
       "automerge": true,
       "separateMinorPatch": false,


### PR DESCRIPTION
I think it's time to stop updating v35, as containerbase major is already blocked

- https://github.com/renovatebot/docker-renovate-full/pull/2203