### PR TITLE
chore(deps): update ghcr.io/renovatebot/base-image docker tag to v1.2.1 (main)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG RENOVATE_VERSION=37.87.2
 
 # Base image
 #============
-FROM ghcr.io/renovatebot/base-image:1.3.0@sha256:4a309a41695dea0f3ec144dde069e0e5c488874219d26f9321110a7c9b80fb2f AS base
+FROM ghcr.io/renovatebot/base-image:1.3.1@sha256:3ab4544ee143e3064cc2cf572df7bcc1b415f77009f330e199e2e1b21b0a38b9 AS base
 
 LABEL name="renovate"
 LABEL org.opencontainers.image.source="https://github.com/renovatebot/renovate" \


### PR DESCRIPTION
- https://github.com/renovatebot/renovate/discussions/26143